### PR TITLE
Update Special:Version link

### DIFF
--- a/DFRawFunctions.php
+++ b/DFRawFunctions.php
@@ -29,7 +29,7 @@ $wgExtensionCredits['parserhook'][] = array(
 	'path'           => __FILE__,
 	'name'           => 'DFRawFunctions',
 	'author'         => 'Quietust',
-	'url'            => 'http://df.magmawiki.com/index.php/User:Quietust',
+	'url'            => 'http://dwarffortresswiki.org/index.php/User:Quietust',
 	'description'    => 'Dwarf Fortress Raw parser functions',
 	'version'        => '1.5',
 );


### PR DESCRIPTION
df.magmawiki.com is no longer working
(`patch-1` is apparently Github's new default branch name for pull requests)
