### PR TITLE
DFRawFunctions.body.php: tagentry: fix str to int comparison

### DIFF
--- a/DFRawFunctions.body.php
+++ b/DFRawFunctions.body.php
@@ -160,7 +160,7 @@ class DFRawFunctions
 			return $notfound;
 		foreach ($tags as $tag)
 		{
-			if ($offset >= count($tag))
+			if ((int)$offset >= count($tag))
 				continue;
 			$match = true;
 			for ($i = 0; $i < $numcaps; $i++)


### PR DESCRIPTION
Default str to int comparison behavior was changed in php8+ https://wiki.php.net/rfc/string_to_number_comparison with is caused undefined behavior in code.
This commit fixes it by explicitly casting offset str to int.